### PR TITLE
Add Bulma CSS Framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "if-env": "^1.0.0"
   },
   "dependencies": {
+    "bulma": "^0.4.2",
     "gh-pages": "^1.0.0",
     "preact": "^8.1.0",
     "preact-cli": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1308,6 +1308,10 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
+bulma@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.4.2.tgz#3be8c832cf6658bfc421ecb41f6dc5a8a0c7c0e5"
+
 bytes@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.3.0.tgz#d5b680a165b6201739acb611542aabc2d8ceb070"


### PR DESCRIPTION
Fixes #5 

Usage:
Add `import 'bulma/css/bulma.css'` on any file.